### PR TITLE
Save mapping for converting repository into task_definition to DB

### DIFF
--- a/app/models/review_app_target.rb
+++ b/app/models/review_app_target.rb
@@ -8,7 +8,7 @@ class ReviewAppTarget
   validates :pr_number, presence: true
 
   def create
-    @task = task_definition.run
+    @task = task_definition.run(self)
     if @task && @task.save
       self
     end
@@ -26,15 +26,11 @@ class ReviewAppTarget
   end
 
   def task_definition
-    @task_definition ||= TaskDefinition.new(review_app_target: self)
+    @task_definition ||= TaskDefinition.find_by(repository: repository)
   end
 
   def task
     @task ||= Task.find_by_review_app_target(self)
-  end
-
-  def task_definition_name
-    @task_definition_name = Settings.task_definition_maps[repository]
   end
 
   def cache_clear_url

--- a/app/models/review_app_target.rb
+++ b/app/models/review_app_target.rb
@@ -9,9 +9,7 @@ class ReviewAppTarget
 
   def create
     @task = task_definition.run(self)
-    if @task && @task.save
-      self
-    end
+    self if @task
   end
 
   def delete

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,8 +3,11 @@ class Task < ApplicationRecord
   has_many :endpoints, dependent: :destroy
 
   validates :arn, presence: true
-  validates :task_definition, presence: true, uniqueness: { scope: :pr_number }
-  validates :pr_number, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+  validates :task_definition, presence: true
+  validates :pr_number,
+    presence: true,
+    numericality: { only_integer: true, greater_than_or_equal_to: 1 },
+    uniqueness: { scope: :task_definition }
   validates :endpoints, presence: true
 
   after_initialize :build_endpoints, if: -> { new_record? && endpoints.blank? }

--- a/app/models/task_definition.rb
+++ b/app/models/task_definition.rb
@@ -1,4 +1,6 @@
 class TaskDefinition < ApplicationRecord
+  has_many :tasks
+
   validates :repository, presence: true, uniqueness: true
   validates :name, presence: true
 
@@ -9,11 +11,11 @@ class TaskDefinition < ApplicationRecord
   def run(review_app_target)
     task_arn = run_task(review_app_target)
     if task_arn
-      Task.new(
+      task = tasks.build(
         arn: task_arn,
-        repository: repository,
         pr_number: review_app_target.pr_number,
       )
+      task if task.save
     end
   end
 

--- a/app/models/task_definition.rb
+++ b/app/models/task_definition.rb
@@ -22,7 +22,7 @@ class TaskDefinition < ApplicationRecord
   def run_task(review_app_target)
     ecs.run_task(
       cluster: Settings.aws.ecs.cluster_name,
-      task_definition: get_latest_arn,
+      task_definition: latest_arn,
       overrides: {
         container_overrides: [
           {
@@ -39,7 +39,7 @@ class TaskDefinition < ApplicationRecord
     ).dig(:tasks, 0, :task_arn)
   end
 
-  def get_latest_arn
+  def latest_arn
     ecs.list_task_definitions(
       family_prefix: name,
       status: 'ACTIVE',

--- a/app/models/task_definition.rb
+++ b/app/models/task_definition.rb
@@ -1,7 +1,8 @@
-class TaskDefinition
-  include ActiveModel::Model
-
+class TaskDefinition < ApplicationRecord
   attr_accessor :review_app_target
+
+  validates :repository, presence: true, uniqueness: true
+  validates :name, presence: true
 
   def exist?
     ecs.list_task_definition_families.families.include?(review_app_target.task_definition_name)

--- a/db/migrate/20170222095544_create_task_definitions.rb
+++ b/db/migrate/20170222095544_create_task_definitions.rb
@@ -1,0 +1,11 @@
+class CreateTaskDefinitions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :task_definitions, unsigned: true do |t|
+      t.string :repository, null: false
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :task_definitions, :repository, unique: true
+  end
+end

--- a/db/migrate/20170222112917_add_task_definition_id_to_and_remove_repository_from_tasks.rb
+++ b/db/migrate/20170222112917_add_task_definition_id_to_and_remove_repository_from_tasks.rb
@@ -1,0 +1,23 @@
+class AddTaskDefinitionIdToAndRemoveRepositoryFromTasks < ActiveRecord::Migration[5.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        change_table :tasks do |t|
+          t.remove_index [:repository, :pr_number]
+          t.remove :repository
+          t.belongs_to :task_definition, foreign_key: true, unsigned: true, null: false, index: false, after: :arn
+        end
+        add_index :tasks, [:task_definition_id, :pr_number], unique: true
+      end
+      dir.down do
+        remove_foreign_key :tasks, :task_definitions
+        change_table :tasks do |t|
+          t.remove_index [:task_definition_id, :pr_number]
+          t.remove :task_definition_id
+          t.string :repository, null: false, after: :arn
+        end
+        add_index :tasks, [:repository, :pr_number], unique: true
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170201065237) do
+ActiveRecord::Schema.define(version: 20170222095544) do
 
   create_table "endpoints", unsigned: true, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "ip",         limit: 15, null: false
@@ -19,6 +19,14 @@ ActiveRecord::Schema.define(version: 20170201065237) do
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
     t.index ["task_id"], name: "index_endpoints_on_task_id", using: :btree
+  end
+
+  create_table "task_definitions", unsigned: true, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "repository", null: false
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["repository"], name: "index_task_definitions_on_repository", unique: true, using: :btree
   end
 
   create_table "tasks", unsigned: true, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170222095544) do
+ActiveRecord::Schema.define(version: 20170222112917) do
 
   create_table "endpoints", unsigned: true, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "ip",         limit: 15, null: false
@@ -30,13 +30,14 @@ ActiveRecord::Schema.define(version: 20170222095544) do
   end
 
   create_table "tasks", unsigned: true, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "arn",        null: false
-    t.string   "repository", null: false
-    t.integer  "pr_number",  null: false, unsigned: true
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["repository", "pr_number"], name: "index_tasks_on_repository_and_pr_number", unique: true, using: :btree
+    t.string   "arn",                null: false
+    t.integer  "task_definition_id", null: false, unsigned: true
+    t.integer  "pr_number",          null: false, unsigned: true
+    t.datetime "created_at",         null: false
+    t.datetime "updated_at",         null: false
+    t.index ["task_definition_id", "pr_number"], name: "index_tasks_on_task_definition_id_and_pr_number", unique: true, using: :btree
   end
 
   add_foreign_key "endpoints", "tasks"
+  add_foreign_key "tasks", "task_definitions"
 end


### PR DESCRIPTION
- task_definitionsテーブルを追加
- taskをtask_definitionの子レコードとして再定義

