### PR TITLE
Fix deprecation warning in routes.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
-    controller :webhooks, as: :webhook, path: :webhooks do
+    scope :webhooks, controller: :webhooks, as: :webhooks do
       post :github_callback
     end
   end


### PR DESCRIPTION
Fix it
```
DEPRECATION WARNING: #controller with options is deprecated. If you need to pass more options than the controller name use #scope. (called from block (2 levels) in <top (required)> at config/routes.rb:3)
```