### PR TITLE
Fix bug in TaskDefinitionLoader for specification of aws sdk.

### DIFF
--- a/app/models/task_definition_loader.rb
+++ b/app/models/task_definition_loader.rb
@@ -23,6 +23,6 @@ class TaskDefinitionLoader
   private
 
   def parse_response(response)
-    YAML.load(Base64.decode64(response[:content])).symbolize_keys
+    YAML.load(Base64.decode64(response[:content])).deep_symbolize_keys
   end
 end


### PR DESCRIPTION
It require symbolized keys at any level of parameters.

e.g.)
> ArgumentError: parameter validator found 2 errors:
>  - missing required parameter params[:container_definitions][0]["log_configuration"][:log_driver]
>  - missing required parameter params[:container_definitions][1]["log_configuration"][:log_driver]