### PR TITLE
Delete AWS ENI when attached instance is terminated

### DIFF
--- a/app/models/spot_fleet_request/spot_instance.rb
+++ b/app/models/spot_fleet_request/spot_instance.rb
@@ -44,7 +44,8 @@ module SpotFleetRequest
         device_index: 0,
         associate_public_ip_address: true,
         subnet_id: subnet_id,
-        groups: [ group_id ]
+        groups: [ group_id ],
+        delete_on_termination: true,
       }
     end
 


### PR DESCRIPTION
インスタンスが死んでもENI残っちゃう問題

※ テストして消えることは確認済み