### PR TITLE
adding guard clause to delete method in review_app_target.rb

### DIFF
--- a/app/models/review_app_target.rb
+++ b/app/models/review_app_target.rb
@@ -13,6 +13,8 @@ class ReviewAppTarget
   end
 
   def delete
+    return if task.nil?
+
     task.stop
     task.destroy
     self


### PR DESCRIPTION
container and task_definition cannot create, if task is not exist when GitHub synchronized action occurs.

task is only created, when PRs were created. 
if error occurs when PR was created, task is not created.

```error_log
/usr/local/review_apps/releases/20170418014012/app/models/review_app_target.rb:16:in `delete': undefined method `stop' for nil:NilClass (NoMethodError)
        from /usr/local/review_apps/releases/20170418014012/app/models/review_app_target.rb:22:in `update'
        from /usr/local/review_apps/releases/20170418014012/app/models/pull_request/actions/synchronized.rb:3:in `handle'
```