### PR TITLE
clearing nginx cache through synchronized actions

### DIFF
--- a/app/models/pull_request/actions/close.rb
+++ b/app/models/pull_request/actions/close.rb
@@ -1,8 +1,6 @@
 class PullRequest::Actions::Close < PullRequest::Actions
   def handle
-    target.cache_clear_urls.each do |url|
-      Net::HTTP.get url
-    end
+    target.clear_nginx_cache
 
     return unless target.delete
     add_comment('ReviewAppsを削除しました')

--- a/app/models/pull_request/actions/close.rb
+++ b/app/models/pull_request/actions/close.rb
@@ -1,11 +1,10 @@
 class PullRequest::Actions::Close < PullRequest::Actions
   def handle
-    return unless target.delete
-
     target.cache_clear_urls.each do |url|
       Net::HTTP.get URI.parse(url)
     end
 
+    return unless target.delete
     add_comment('ReviewAppsを削除しました')
   end
 end

--- a/app/models/pull_request/actions/close.rb
+++ b/app/models/pull_request/actions/close.rb
@@ -1,7 +1,7 @@
 class PullRequest::Actions::Close < PullRequest::Actions
   def handle
     target.cache_clear_urls.each do |url|
-      Net::HTTP.get URI.parse(url)
+      Net::HTTP.get url
     end
 
     return unless target.delete

--- a/app/models/pull_request/actions/close.rb
+++ b/app/models/pull_request/actions/close.rb
@@ -2,6 +2,10 @@ class PullRequest::Actions::Close < PullRequest::Actions
   def handle
     return unless target.delete
 
+    target.cache_clear_urls.each do |url|
+      Net::HTTP.get URI.parse(url)
+    end
+
     add_comment('ReviewAppsを削除しました')
   end
 end

--- a/app/models/pull_request/actions/synchronized.rb
+++ b/app/models/pull_request/actions/synchronized.rb
@@ -1,8 +1,9 @@
 class PullRequest::Actions::Synchronized < PullRequest::Actions
   def handle
     target.cache_clear_urls.each do |url|
-      Net::HTTP.get URI.parse(url)
+      Net::HTTP.get url
     end
+
     return unless target.update
 
     add_comment(message)

--- a/app/models/pull_request/actions/synchronized.rb
+++ b/app/models/pull_request/actions/synchronized.rb
@@ -1,9 +1,6 @@
 class PullRequest::Actions::Synchronized < PullRequest::Actions
   def handle
-    target.cache_clear_urls.each do |url|
-      Net::HTTP.get url
-    end
-
+    target.clear_nginx_cache
     return unless target.update
 
     add_comment(message)

--- a/app/models/pull_request/actions/synchronized.rb
+++ b/app/models/pull_request/actions/synchronized.rb
@@ -2,7 +2,9 @@ class PullRequest::Actions::Synchronized < PullRequest::Actions
   def handle
     return unless target.update
 
-    Net::HTTP.get URI.parse(target.cache_clear_url)
+    target.cache_clear_urls.each do |url|
+      Net::HTTP.get URI.parse(url)
+    end
 
     add_comment(message)
   end

--- a/app/models/pull_request/actions/synchronized.rb
+++ b/app/models/pull_request/actions/synchronized.rb
@@ -1,10 +1,9 @@
 class PullRequest::Actions::Synchronized < PullRequest::Actions
   def handle
-    return unless target.update
-
     target.cache_clear_urls.each do |url|
       Net::HTTP.get URI.parse(url)
     end
+    return unless target.update
 
     add_comment(message)
   end

--- a/app/models/review_app_target.rb
+++ b/app/models/review_app_target.rb
@@ -34,7 +34,7 @@ class ReviewAppTarget
   end
 
   def cache_clear_url
-    "#{target.endpoint}/review_apps/clear"
+    "#{task.endpoint}/review_apps/clear"
   end
 
   private

--- a/app/models/review_app_target.rb
+++ b/app/models/review_app_target.rb
@@ -33,9 +33,9 @@ class ReviewAppTarget
     @task ||= Task.find_by_review_app_target(self)
   end
 
-  def cache_clear_urls
-    task.endpoints.map do |endpoint|
-      URI(endpoint.url).merge('/review_apps/clear')
+  def clear_nginx_cache
+    cache_clear_urls.each do |url|
+      Net::HTTP.get url
     end
   end
 
@@ -44,5 +44,11 @@ class ReviewAppTarget
   def create_task_definition!
     loader = TaskDefinitionLoader.new(self)
     TaskDefinition.register!(repository, loader.load)
+  end
+
+  def cache_clear_urls
+    task.endpoints.map do |endpoint|
+      URI(endpoint.url).merge('/review_apps/clear')
+    end
   end
 end

--- a/app/models/review_app_target.rb
+++ b/app/models/review_app_target.rb
@@ -33,8 +33,10 @@ class ReviewAppTarget
     @task ||= Task.find_by_review_app_target(self)
   end
 
-  def cache_clear_url
-    "#{task.endpoint}/review_apps/clear"
+  def cache_clear_urls
+    task.endpoints.map do |endpoint|
+      "#{endpoint.url}/review_apps/clear"
+    end
   end
 
   private

--- a/app/models/review_app_target.rb
+++ b/app/models/review_app_target.rb
@@ -35,7 +35,7 @@ class ReviewAppTarget
 
   def cache_clear_urls
     task.endpoints.map do |endpoint|
-      "#{endpoint.url}/review_apps/clear"
+      URI(endpoint.url).merge('/review_apps/clear')
     end
   end
 


### PR DESCRIPTION
## やりたいこと
存在しなくなった taskへの、nginxのURL cacheを消しちゃいたい

https://github.com/speee/webapp-revieee/issues/43
↑とも関係がある。

## 確認内容

- [x] cacheがある状態でcacheを消す
- [x] cacheが無い状態でcacheを消そうとする

## 確認方法
一時的にmysqlのgeneral.logが取れるようにして、上記の状態でlogが流れるか見る。

## 確認結果
**cacheがある状態でアクセス**

mysqlのgeneral_logにqueryが発行されていないことを確認

**cacheが無い状態でcacheを消してアクセス**

mysql の queryが発行されていることを確認


```mysql_log
*************************** 8. row ***************************
  event_time: 2017-05-02 10:27:59.574302
   user_host: review_apps[review_apps] @ localhost [127.0.0.1]
   thread_id: 1835
   server_id: 0
command_type: Execute
    argument: SELECT * FROM endpoints WHERE id = 278
```

## 関係するPR
https://github.com/speee/dev-review-apps-itamae/pull/11